### PR TITLE
add brightness control toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.0] - 2022-05-23
+## [0.4.0] - 2022-07-26
+
+### Added
+
+- Brightness control knob is now disabled by default and can be enabled by setting associated boolean.
+
+## [0.3.0] - 2022-07-25
 
 ### Changed
 

--- a/led-lamp-software.ino
+++ b/led-lamp-software.ino
@@ -45,6 +45,7 @@ uint8_t modeSwitch;
 uint8_t currentMode = 1;
 uint8_t hue = 0;
 uint8_t outputBrightness;
+bool controlBrightness = false; // Turn on external brightness control pot.
 
 void setup()
 {
@@ -60,7 +61,15 @@ void setup()
 void loop()
 {
   modeSwitch = digitalRead(MODE_PIN);
-  updateBrightness();
+
+  if (controlBrightness) // Checks to see if there is a knob installed, and adjusts brightness to current setting.
+  {
+    updateBrightness();
+  }
+  else
+  {
+    FastLED.setBrightness(MAX_BRIGHTNESS);
+  }
 
   if (modeSwitch == HIGH) // Might need to add debounce. Open an issue on github if needed.
   {


### PR DESCRIPTION
Allows the brightness control knob to be enabled and disabled, leaving the lamp at configured max brightness.

Updated changelog.