### PR TITLE
Fix brightness knob check bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.1] - 2022-07-26
+
+### Bugfix
+
+- Brightness knob check wasn't actually setting a value if no knob was present. Will default to MAX_BRIGHTNESS value.
+
 ## [0.4.0] - 2022-07-26
 
 ### Added

--- a/led-lamp-software.ino
+++ b/led-lamp-software.ino
@@ -45,7 +45,7 @@ uint8_t modeSwitch;
 uint8_t currentMode = 1;
 uint8_t hue = 0;
 uint8_t outputBrightness;
-bool controlBrightness = false; // Turn on external brightness control pot.
+bool controlBrightness = false; // Enable external brightness control pot.
 
 void setup()
 {
@@ -68,7 +68,7 @@ void loop()
   }
   else
   {
-    FastLED.setBrightness(MAX_BRIGHTNESS);
+    outputBrightness = MAX_BRIGHTNESS;
   }
 
   if (modeSwitch == HIGH) // Might need to add debounce. Open an issue on github if needed.


### PR DESCRIPTION
If check for brightness knob was not setting a value if knob was not enabled. Will now default to defined max_brightness.